### PR TITLE
BlynkのBLEで操作出来るように対応

### DIFF
--- a/master/master.ino
+++ b/master/master.ino
@@ -1,5 +1,8 @@
-b#include <nRF24L01.h>
+#include <nRF24L01.h>
 #include <RF24.h>
+#include <BlynkSimpleEsp32_BLE.h>
+#include <BLEDevice.h>
+#include <BLEServer.h>
 #define button 0                        
 int request;
 RTC_DATA_ATTR int keyStatus;
@@ -7,6 +10,7 @@ RTC_DATA_ATTR int keyStatus;
 RF24 radio(4, 22);               // CE,CSNピンの指定
 const byte address[6] = "00001";  // データを受信するアドレス
 
+char auth[] = "YourAuthToken";
 void setup()
 {
   // シリアルポートの初期化
@@ -19,10 +23,15 @@ void setup()
   radio.setPALevel(RF24_PA_MIN);  // 出力を最小に
   radio.stopListening();          // 送信側として設定
   
+  Blynk.setDeviceName("Blynk");
+
+  Blynk.begin(auth);
+  Blynk.run();
 }
 
 void loop()
 {      
+  Blynk.run();
   if(digitalRead(button)==0)
   {
     radio.write(&request, sizeof(request)); 

--- a/slave/slave.ino
+++ b/slave/slave.ino
@@ -68,7 +68,7 @@ void setup()
     }
   }          
   
-  esp_sleep_enable_timer_wakeup(1000000);
+  esp_sleep_enable_timer_wakeup(2 * 1000 * 1000);
   esp_deep_sleep_start();
 }
 


### PR DESCRIPTION
これによりスマホから操作が可能になりました。
ついでにslaveのwakeupを2秒に延ばして省電力をはかりました。