### PR TITLE
毎日再起動で時間を合わせる対応

### DIFF
--- a/master/master.ino
+++ b/master/master.ino
@@ -3,6 +3,8 @@
 #include <BlynkSimpleEsp32_BLE.h>
 #include <BLEDevice.h>
 #include <BLEServer.h>
+#include <WiFi.h>
+#include <time.h>
 #define button 0                        
 int request;
 RTC_DATA_ATTR int keyStatus;
@@ -11,10 +13,45 @@ RF24 radio(4, 22);               // CE,CSNピンの指定
 const byte address[6] = "00001";  // データを受信するアドレス
 
 char auth[] = "YourAuthToken";
+
+const char* ssid       = "YOUR_SSID";
+const char* password   = "YOUR_PASS";
+
+const char* ntpServer = "pool.ntp.org";
+const long  gmtOffset_sec = 3600*9;
+const int   daylightOffset_sec = 0;
+
+void printLocalTime()
+{
+  struct tm timeinfo;
+  if(!getLocalTime(&timeinfo)){
+    Serial.println("Failed to obtain time");
+    return;
+  }
+  Serial.println(&timeinfo, "%A, %B %d %Y %H:%M:%S");
+}
+
 void setup()
 {
   // シリアルポートの初期化
   Serial.begin(115200);
+
+  //WiFiに接続する
+  Serial.printf("Connecting to %s ", ssid);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+      delay(500);
+      Serial.print(".");
+  }
+  Serial.println(" CONNECTED");
+
+  //時間を初期化
+  configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
+  printLocalTime();
+
+  //不要になったWiFiを切り離す
+  WiFi.disconnect(true);
+  WiFi.mode(WIFI_OFF);
 
   pinMode(button, INPUT);
 


### PR DESCRIPTION
- 時計を持つことで使わない時間帯(1時~6時など)は省電力モードにする為
- ESP32の時計は精度が良くないので(12時間で1.7秒ほどズレる)毎日再起動し時間を習得し直す